### PR TITLE
Fix address of the "RFC2119" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,6 @@ If you’d like to leave feedback, please
 [one-sentence-per-line]: http://rhodesmill.org/brandon/2012/one-sentence-per-line/
 [orgmode]: http://orgmode.org
 [restructuredtext]: http://docutils.sourceforge.net/rst.html
-[rfc2119]: https://www.ietf.org/rfc/rfc2119
+[rfc2119]: https://www.ietf.org/rfc/rfc2119.txt
 [semver]: http://semver.org
 [udhr]: http://www.un.org/en/universal-declaration-human-rights/


### PR DESCRIPTION
These two URLs seem to point to the same text file:

- https://www.ietf.org/rfc/rfc2119
- https://www.ietf.org/rfc/rfc2119.txt

Both open correctly in Chrome,
but in Firefox on Windows,
the former triggers a download popup:

![Firefox's download popup](https://user-images.githubusercontent.com/2226144/98350993-c458d680-2024-11eb-8f57-c8576c0ccd29.png)