### PR TITLE
Redeploy sembr.org when the specification changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy
+
+# sembr.org fetches this README at build time,
+# but Cloudflare Workers Builds only rebuilds the site
+# when the sembr.org repository itself changes.
+# Rebuild and redeploy it whenever the specification changes.
+
+on:
+  push:
+    branches: [main]
+    paths: [README.md]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Build and deploy sembr.org
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out sembr/sembr.org
+        uses: actions/checkout@v7
+        with:
+          repository: sembr/sembr.org
+          ref: main
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and deploy
+        run: npm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
sembr.org renders this README by fetching it from `raw.githubusercontent.com` at build time, but Cloudflare Workers Builds only rebuilds the site when the sembr.org repository itself changes. So edits here never reach the site until something else lands there.

This workflow rebuilds and redeploys the site on every push to `main` that touches `README.md` (and on manual dispatch): it checks out sembr/sembr.org, runs `npm ci`, then `npm run deploy`, which is the same `astro build` + `wrangler deploy` the site's own README documents.